### PR TITLE
Let GitHub render correctly README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Then you should have the image good to go inside your current working directory.
 
 ## Install required packages (Debian)
 ```
-apt-get install vmdebootstrap ```
+apt-get install vmdebootstrap
+```
 
 ## Building lepidopter image
 Run the main build script:


### PR DESCRIPTION
Before this change, GitHub rendered README.md in a strange way (see image).

![screen shot 2015-08-29 at 15 14 17](https://cloud.githubusercontent.com/assets/337298/9562035/bae465e2-4e60-11e5-8b14-535926e6653f.png)

After everything is pleasant and readable (see image).

![screen shot 2015-08-29 at 15 15 29](https://cloud.githubusercontent.com/assets/337298/9562041/d758774a-4e60-11e5-8ff3-0f10c530319b.png)
