### PR TITLE
Improve log rotate to use less disk space

### DIFF
--- a/lepidopter-fh/etc/logrotate.d/ooniprobe
+++ b/lepidopter-fh/etc/logrotate.d/ooniprobe
@@ -1,9 +1,10 @@
 /var/log/ooni/*.log {
-    monthly
+    weekly
     missingok
     rotate 2
     compress
     delaycompress
     copytruncate
     maxsize 10M
+    notifempty
 }


### PR DESCRIPTION
Rotate logs weekly (first day of the week)
Do not rotate logs if they are empty
