### PR TITLE
Fix: no need to change dir

### DIFF
--- a/lepidopter-fh/opt/ooni/update-deck.sh
+++ b/lepidopter-fh/opt/ooni/update-deck.sh
@@ -3,9 +3,8 @@ source /etc/ooniprobe/ooniconfig.sh
 
 echo "$(date) Updating deck" >> ${OONI_CRONJOBS_LOG}
 # Build the deck and configure it 
-cd ${OONI_HOME}
-OONI_DECK=$(oonideckgen -o decks/ | tee -a ${OONI_CRONJOBS_LOG} |
- grep ^ooniprobe | cut -d ' ' -f3)
+OONI_DECK=$(oonideckgen --output=${OONI_HOME}/decks/ |
+tee -a ${OONI_CRONJOBS_LOG} | grep ^ooniprobe | cut -d ' ' -f3)
 echo "#ooniprobe deck update: $(date)" > ${OONI_DECK_CONFIG}
 echo "OONI_DECK=${OONI_DECK}" >> ${OONI_DECK_CONFIG}
 echo "$(date) done updating deck" >> ${OONI_CRONJOBS_LOG}


### PR DESCRIPTION
oonideckgen can generate decks to a specified PATH
