### PR TITLE
Hotfix: Cleanup ooniprobe logrotated files

### DIFF
--- a/lepidopter-fh/etc/cron.daily/remove_old_logs
+++ b/lepidopter-fh/etc/cron.daily/remove_old_logs
@@ -1,0 +1,7 @@
+#!/bin/bash
+# This cronjob has been created to overcome a limitation of ooniprobe log
+# rotations. It deletes files modified by the pattern 'ooniprobe.log.*_*' the
+# last 6 days for the ${OONI_LOGS} directory
+source /etc/ooniprobe/ooniconfig.sh
+
+find ${OONI_LOGS} -name "ooniprobe.log.*_*" -mtime +6 -type f -delete

--- a/lepidopter-fh/etc/logrotate.d/ooniprobe
+++ b/lepidopter-fh/etc/logrotate.d/ooniprobe
@@ -8,22 +8,11 @@
     notifempty
 }
 
-/var/log/ooni/oonireport.log {
+/var/log/ooni/oonireport.log.* {
     missingok
     rotate 1
     compress
-    delaycompress
     copytruncate
     maxsize 1M
     notifempty
-}
-
-/var/log/ooni/ooniprobe.log {
-    daily
-    missingok
-    rotate 7
-    compress
-    delaycompress
-    copytruncate
-    maxsize 100M
 }

--- a/lepidopter-fh/etc/ooniprobe/ooniconfig.sh
+++ b/lepidopter-fh/etc/ooniprobe/ooniconfig.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
+OONI_LOGS="/var/log/ooni"
 OONI_CONFIG="/etc/ooniprobe/ooniprobe.conf"
 OONI_HOME="/opt/ooni"
 OONI_REPORTS="/opt/ooni/reports"
 OONI_DECK_CONFIG="/etc/ooniprobe/oonideckconfig"
-OONI_CRONJOBS_LOG="/var/log/ooni/cronjobs.log"
-OONIREPORT_LOG="/var/log/ooni/oonireport.log"
+OONI_CRONJOBS_LOG="${OONI_LOGS}/cronjobs.log"
+OONIREPORT_LOG="${OONI_LOGS}/oonireport.log"
 OONIREPORT_CONFIG="/etc/ooniprobe/oonireport.conf"
 
 datestamp=$(date -u +"%d-%m-%y %R")


### PR DESCRIPTION
This hotfix introduces a new cronjob to delete the rotated log files
that ooniprobe produces. The rotated are never being nor can be
maintained by logrotate since this results to a binary file.
Ref: https://github.com/TheTorProject/ooni-probe/issues/502
- Add remove_old_logs cronjob
- Add minor variable changes
- Remove logrotate ooniprobe.log conf
- Change logrotate oonireport.log conf so that it will not mess up with
  ooniprobe
