### PR TITLE
Zip image, test verify signatures, use config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ distribution.
 ```
 .
 ├── conf
+│   ├── lepidopter-image.conf
 │   └── tor-pt.conf Tor bridges and pluggable transports configuration file
 ├── customize       customize script used to customize lepidopter image
 ├── images          where the build Lepidopter images created

--- a/conf/lepidopter-image.conf
+++ b/conf/lepidopter-image.conf
@@ -1,0 +1,9 @@
+USER="lepidopter"
+PASSWD="lepidopter"
+DEB_RELEASE="jessie"
+HOSTNAME_IMG="lepidopter"
+ARCH="armel"
+APT_MIRROR="http://httpredir.debian.org/debian"
+# Uncomment next line to use apt-cacher-ng
+#MIRROR="http://localhost:3142/debian"
+MIRROR="http://httpredir.debian.org/debian"

--- a/lepidopter-vmdebootstrap_build.sh
+++ b/lepidopter-vmdebootstrap_build.sh
@@ -2,16 +2,7 @@
 set -exa
 
 source lepidopter-fh/etc/default/lepidopter
-
-USER="lepidopter"
-PASSWD="lepidopter"
-DEB_RELEASE="jessie"
-HOSTNAME_IMG="lepidopter"
-ARCH="armel"
-APT_MIRROR="http://httpredir.debian.org/debian"
-# Uncomment next line to use apt-cacher-ng
-#MIRROR="http://localhost:3142/debian"
-MIRROR="http://httpredir.debian.org/debian"
+source conf/lepidopter-image.conf
 
 vmdebootstrap \
     --arch ${ARCH} \

--- a/scripts/lepidopter-sign.sh
+++ b/scripts/lepidopter-sign.sh
@@ -6,11 +6,14 @@ LEPIDOPTER_SIGN_KEY="0xBA56AC5A53E9C7A4"
 
 echo "Compute SHA message digests..."
 cd $DIR
-sha1sum *.xz > SHA1SUM
-sha256sum *.xz > SHA256SUM
-sha512sum *.xz > SHA512SUM
+sha1sum *.xz *.zip > SHA1SUM
+sha256sum *.xz *.zip > SHA256SUM
+sha512sum *.xz *.zip > SHA512SUM
 
 echo "Signing..."
 for f in * ; do
     gpg2 --verbose --armor --default-key ${LEPIDOPTER_SIGN_KEY} --detach-sign $f
 done
+
+echo "Test verify signatures..."
+gpg2 --verify-files *.asc


### PR DESCRIPTION
- Add zip archive support on build script
- Test verify GPG signatures of images and digests
- Use a common configuration file
