### PR TITLE
Change update precedence of ooniprobe and deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ distribution.
 
 ```
 .
+├── Changelog.rst
 ├── conf
 │   ├── lepidopter-image.conf
 │   └── tor-pt.conf Tor bridges and pluggable transports configuration file
@@ -22,15 +23,14 @@ distribution.
 │   │   │   └── apt.conf.d
 │   │   │       └── 02compress-indexes
 │   │   ├── cron.daily      daily cronjobs
+│   │   │   ├── remove_old_logs
 │   │   │   ├── remove_upl_reports
 │   │   │   ├── run_ooniprobe_deck
 │   │   │   └── upload_reports
+│   │   ├── crontab
 │   │   ├── cron.weekly     weekly cronjobs
 │   │   │   ├── remove_inc_reports
-│   │   │   ├── update_deck
-│   │   │   └── update_ooniprobe
-│   │   ├── default
-│   │   │   └── lepidopter
+│   │   │   └── update_ooniprobe_deck
 │   │   ├── dpkg
 │   │   │   └── dpkg.cfg.d
 │   │   │       └── 01_nodoc
@@ -56,6 +56,7 @@ distribution.
 │   │       ├── remove-upl-reports.sh
 │   │       ├── reports
 │   │       ├── run-ooniprobe.sh
+│   │       ├── tor_data_dir
 │   │       ├── update-deck.sh
 │   │       ├── update-ooniprobe.sh
 │   │       └── upload-reports.sh
@@ -65,13 +66,11 @@ distribution.
 │       └── log
 │           └── ooni
 ├── lepidopter-vmdebootstrap_build.sh   main lepidopter vmdebootstrap script
-├── scripts         external scripts 
-│   └── setup.sh    install dependencies needed to create and build the image 
 ├── LICENSE.md
 ├── README.md       you are currently reading it
-├── scripts
+├── scripts         external scripts
 │   ├── lepidopter-sign.sh
-│   └── setup.sh
+│   └── setup.sh    install dependencies needed to create and build the image 
 └── Vagrantfile
 ```
 

--- a/lepidopter-fh/etc/cron.weekly/update_deck
+++ b/lepidopter-fh/etc/cron.weekly/update_deck
@@ -1,2 +1,0 @@
-#!/bin/bash
-/opt/ooni/update-deck.sh

--- a/lepidopter-fh/etc/cron.weekly/update_ooniprobe
+++ b/lepidopter-fh/etc/cron.weekly/update_ooniprobe
@@ -1,2 +1,0 @@
-#!/bin/bash
-/opt/ooni/update-ooniprobe.sh

--- a/lepidopter-fh/etc/cron.weekly/update_ooniprobe_deck
+++ b/lepidopter-fh/etc/cron.weekly/update_ooniprobe_deck
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Update ooniprobe and deck
+/opt/ooni/update-ooniprobe.sh
+/opt/ooni/update-deck.sh

--- a/lepidopter-fh/etc/crontab
+++ b/lepidopter-fh/etc/crontab
@@ -1,0 +1,15 @@
+# /etc/crontab: system-wide crontab
+# Unlike any other crontab you don't have to run the `crontab'
+# command to install the new version when you edit this file
+# and files in /etc/cron.d. These files also have username fields,
+# that none of the other crontabs do.
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# m h dom mon dow user	command
+17 *	* * *	root    cd / && run-parts --report /etc/cron.hourly
+25 6	* * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
+17 4	* * 7	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )
+52 6	1 * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
+#


### PR DESCRIPTION
This fixes https://github.com/TheTorProject/lepidopter/issues/44
- ooniprobe is being updated prior deck update
- Make sure that weekly ooniprobe/deck updates happen before the daily
  ooniprobe cronjob
