### PR TITLE
Fix set timezone to UTC

### DIFF
--- a/customize
+++ b/customize
@@ -58,6 +58,10 @@ rsync -avp lepidopter-fh/ ${ROOTDIR}/
 chroot ${ROOTDIR} /setup-ooniprobe.sh
 rm ${ROOTDIR}/setup-ooniprobe.sh
 
+# OS configure script
+chroot ${ROOTDIR} /configure.sh
+rm ${ROOTDIR}/configure.sh
+
 # Execute cleanup script
 chroot ${ROOTDIR} /cleanup.sh
 rm ${ROOTDIR}/cleanup.sh

--- a/lepidopter-fh/configure.sh
+++ b/lepidopter-fh/configure.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+# Set locatime to UTC
+cp /usr/share/zoneinfo/UTC /etc/localtime

--- a/lepidopter-fh/etc/default/hwclock
+++ b/lepidopter-fh/etc/default/hwclock
@@ -1,0 +1,19 @@
+# Defaults for the hwclock init script.  See hwclock(5) and hwclock(8).
+
+# This is used to specify that the hardware clock incapable of storing
+# years outside the range of 1994-1999.  Set to yes if the hardware is
+# broken or no if working correctly.
+#BADYEAR=no
+
+# Set this to yes if it is possible to access the hardware clock,
+# or no if it is not.
+HWCLOCKACCESS=no
+
+# Set this to any options you might need to give to hwclock, such
+# as machine hardware clock type for Alphas.
+#HWCLOCKPARS=
+
+# Set this to the hardware clock device you want to use, it should
+# probably match the CONFIG_RTC_HCTOSYS_DEVICE kernel config option.
+#HCTOSYS_DEVICE=rtc0
+

--- a/lepidopter-fh/etc/default/rcS
+++ b/lepidopter-fh/etc/default/rcS
@@ -1,0 +1,24 @@
+#
+# /etc/default/rcS
+#
+# Default settings for the scripts in /etc/rcS.d/
+#
+# For information about these variables see the rcS(5) manual page.
+#
+# This file belongs to the "initscripts" package.
+
+# delete files in /tmp during boot older than x days.
+# '0' means always, -1 or 'infinite' disables the feature
+#TMPTIME=0
+
+# spawn sulogin during boot, continue normal boot if not used in 30 seconds
+#SULOGIN=no
+
+# do not allow users to log in until the boot has completed
+#DELAYLOGIN=no
+
+# be more verbose during the boot process
+#VERBOSE=no
+
+# automatically repair filesystems with inconsistencies during boot
+FSCKFIX=yes


### PR DESCRIPTION
This ensures that UTC timezone is being used. Fixes:
https://github.com/TheTorProject/lepidopter/issues/52

Additional relevant modifications:
- Do not access hwclock (Raspberry Pi doesn't have one, using
  fake-hwclock)
- Enable autorepair of filesystems with inconsistencies during boot
  without human intervention.
